### PR TITLE
[Feature] Units conversion using parameters

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ flask-restful = "~=0.3"
 flask-caching = "~=1.10"
 requests = "~=2.25"
 schematics = "~=2.1"
+unidecode = "~=1.2"
 
 [dev-packages]
 pytest = "~=6.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "13e9df9eb30f34bd260a22292c01201004b988126c4a0d5779660c861b72103d"
+            "sha256": "d2505661c629b8bc51a9e6dae2e7939cac45143b1c445e77e81f1aa122b3502c"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0bec2450146784c9961652c4a44995a4a78b6bdfcbec60d9a87e628340c317b1"
+            "sha256": "13e9df9eb30f34bd260a22292c01201004b988126c4a0d5779660c861b72103d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -175,6 +175,14 @@
                 "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
             ],
             "version": "==1.15.0"
+        },
+        "unidecode": {
+            "hashes": [
+                "sha256:12435ef2fc4cdfd9cf1035a1db7e98b6b047fe591892e81f34e94959591fad00",
+                "sha256:8d73a97d387a956922344f6b74243c2c6771594659778744b2dbdaad8f6b727d"
+            ],
+            "index": "pypi",
+            "version": "==1.2.0"
         },
         "urllib3": {
             "hashes": [

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -18,7 +18,6 @@ cache = Cache(app,
 )
 
 cache.init_app(app)
-cache.set('weather_list', [])
 
 # Create a Flask RESTful Api instance
 api = Api(app)

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -18,6 +18,7 @@ cache = Cache(app,
 )
 
 cache.init_app(app)
+cache.set('weather_list', [])
 
 # Create a Flask RESTful Api instance
 api = Api(app)

--- a/api/models/weather.py
+++ b/api/models/weather.py
@@ -1,9 +1,49 @@
 from schematics.models import Model
 from schematics.types import FloatType, GeoPointType, ModelType, StringType
+from schematics.types.serializable import serializable
+from enum import Enum
 
 class PhysicalQuantity(Model):
     value = FloatType(required=True)
     unit = StringType(required=True)
+
+class Temperature(Model):
+    value = FloatType(required=True)
+
+    class TemperatureMetrics(Enum):
+        CELSIUS = 1
+        FAHRENHEIT = 2
+        KELVIN = 3
+
+    @serializable(type=FloatType, serialized_name='value')
+    def get_temperature(self, *args, **kwargs):
+        if hasattr(self, 'context'):
+            temperature = self.context.get('temperature', 'kelvin')
+
+            if temperature.upper() == self.TemperatureMetrics.CELSIUS.name:
+                value = round(self.value - 273.0, 2) # Converts Kelvin temperature to Celsius
+            elif temperature.upper() == self.TemperatureMetrics.FAHRENHEIT.name:
+                value = round(1.8*(self.value-273.0)+32.0, 2) # Converts Kelvin temperature to Fahrenheit
+            else:
+                value = round(self.value, 2) # Returns Kelvin temperature
+        else:
+            value = round(self.value, 2) # Returns Kelvin temperature
+        return value
+
+    @serializable(type=StringType, serialized_name='unit')
+    def get_unit(self, *args, **kwargs):
+        if hasattr(self, 'context'):
+            unit = self.context.get('temperature', 'kelvin')
+
+            if unit.upper() == self.TemperatureMetrics.CELSIUS.name:
+                unit = self.TemperatureMetrics.CELSIUS
+            elif unit.upper() == self.TemperatureMetrics.FAHRENHEIT.name:
+                unit = self.TemperatureMetrics.FAHRENHEIT
+            else:
+                unit = self.TemperatureMetrics.KELVIN
+        else:
+            unit = self.TemperatureMetrics.KELVIN
+        return unit.name.lower()
 
 
 class City(Model):
@@ -27,10 +67,10 @@ class Weather(Model):
     city = ModelType(City, required=True)
     description = StringType(required=True)
     long_description = StringType(required=True)
-    temperature = ModelType(PhysicalQuantity, required=True)
-    feels_like = ModelType(PhysicalQuantity)
-    max_temperature = ModelType(PhysicalQuantity)
-    min_temperature = ModelType(PhysicalQuantity)
+    temperature = ModelType(Temperature, required=True)
+    feels_like = ModelType(Temperature)
+    max_temperature = ModelType(Temperature)
+    min_temperature = ModelType(Temperature)
     wind = ModelType(Wind, required=True)
     visibility = ModelType(PhysicalQuantity)
 

--- a/api/models/weather.py
+++ b/api/models/weather.py
@@ -76,9 +76,9 @@ class Distance(Model):
         if hasattr(self, 'context'):
             unit = self.context.get('distance', 'meters')
 
-            if unit.lower() == self.DistanceMetrics.KILOMETERS:
+            if unit.upper() == self.DistanceMetrics.KILOMETERS:
                 unit = self.DistanceMetrics.KILOMETERS
-            elif unit.lower() == self.DistanceMetrics.MILES:
+            elif unit.upper() == self.DistanceMetrics.MILES:
                 unit = self.DistanceMetrics.MILES
             else:
                 unit = self.DistanceMetrics.METERS

--- a/api/models/weather.py
+++ b/api/models/weather.py
@@ -1,6 +1,7 @@
 from schematics.models import Model
 from schematics.types import FloatType, GeoPointType, ModelType, StringType
 from schematics.types.serializable import serializable
+from unidecode import unidecode
 from api.utils.metatypes import EnumMeta
 
 class PhysicalQuantity(Model):
@@ -116,3 +117,7 @@ class Weather(Model):
 
     class Options:
         serialize_when_none = False
+
+    @serializable(type=StringType, serialized_name='id')
+    def id(self):
+        return unidecode(f'{self.city.name.upper()}')

--- a/api/models/weather.py
+++ b/api/models/weather.py
@@ -7,6 +7,7 @@ class PhysicalQuantity(Model):
     value = FloatType(required=True)
     unit = StringType(required=True)
 
+
 class Temperature(Model):
     value = FloatType(required=True)
 
@@ -46,6 +47,45 @@ class Temperature(Model):
         return unit.name.lower()
 
 
+class Distance(Model):
+    value = FloatType(required=True)
+
+    class DistanceMetrics(Enum):
+        METERS = 1
+        KILOMETERS = 2
+        MILES = 3
+
+    @serializable(type=FloatType, serialized_name='value')
+    def get_distance(self, *args, **kwargs):
+        if hasattr(self, 'context'):
+            distance = self.context.get('distance', 'meters')
+
+            if distance.upper() == self.DistanceMetrics.KILOMETERS.name:
+                value = round(self.value / 1000, 2) # Converts Meters distance to Kilometers
+            elif distance.upper() == self.DistanceMetrics.MILES.name:
+                value = round(self.value / 1609.344, 2) # Converts Meters distance to Miles
+            else:
+                value = round(self.value, 2) # Returns Meters distance
+        else:
+            value = round(self.value, 2) # Returns Meters distance
+        return value
+
+    @serializable(type=StringType, serialized_name='unit')
+    def get_unit(self, *args, **kwargs):
+        if hasattr(self, 'context'):
+            unit = self.context.get('distance', 'kelvin')
+
+            if unit.upper() == self.DistanceMetrics.KILOMETERS.name:
+                unit = self.DistanceMetrics.KILOMETERS
+            elif unit.upper() == self.DistanceMetrics.MILES.name:
+                unit = self.DistanceMetrics.MILES
+            else:
+                unit = self.DistanceMetrics.METERS
+        else:
+            unit = self.DistanceMetrics.METERS
+        return unit.name.lower()
+
+
 class City(Model):
     name = StringType(required=True)
     country = StringType()
@@ -72,7 +112,7 @@ class Weather(Model):
     max_temperature = ModelType(Temperature)
     min_temperature = ModelType(Temperature)
     wind = ModelType(Wind, required=True)
-    visibility = ModelType(PhysicalQuantity)
+    visibility = ModelType(Distance)
 
     class Options:
         serialize_when_none = False

--- a/api/models/weather.py
+++ b/api/models/weather.py
@@ -1,7 +1,7 @@
 from schematics.models import Model
 from schematics.types import FloatType, GeoPointType, ModelType, StringType
 from schematics.types.serializable import serializable
-from enum import Enum
+from api.utils.metatypes import EnumMeta
 
 class PhysicalQuantity(Model):
     value = FloatType(required=True)
@@ -11,19 +11,19 @@ class PhysicalQuantity(Model):
 class Temperature(Model):
     value = FloatType(required=True)
 
-    class TemperatureMetrics(Enum):
-        CELSIUS = 'celsius'
-        FAHRENHEIT = 'fahrenheit'
-        KELVIN = 'kelvin'
+    class TemperatureMetrics(StringType, metaclass=EnumMeta):
+        CELSIUS = 'CELSIUS'
+        FAHRENHEIT = 'FAHRENHEIT'
+        KELVIN = 'KELVIN'
 
     @serializable(type=FloatType, serialized_name='value')
     def get_temperature(self, *args, **kwargs):
         if hasattr(self, 'context'):
             temperature = self.context.get('temperature', 'kelvin')
 
-            if temperature.lower() == self.TemperatureMetrics.CELSIUS.value:
+            if temperature.upper() == self.TemperatureMetrics.CELSIUS:
                 value = round(self.value - 273.0, 2) # Converts Kelvin temperature to Celsius
-            elif temperature.lower() == self.TemperatureMetrics.FAHRENHEIT.value:
+            elif temperature.upper() == self.TemperatureMetrics.FAHRENHEIT:
                 value = round(1.8*(self.value-273.0)+32.0, 2) # Converts Kelvin temperature to Fahrenheit
             else:
                 value = round(self.value, 2) # Returns Kelvin temperature
@@ -36,33 +36,33 @@ class Temperature(Model):
         if hasattr(self, 'context'):
             unit = self.context.get('temperature', 'kelvin')
 
-            if unit.lower() == self.TemperatureMetrics.CELSIUS.value:
+            if unit.upper() == self.TemperatureMetrics.CELSIUS:
                 unit = self.TemperatureMetrics.CELSIUS
-            elif unit.lower() == self.TemperatureMetrics.FAHRENHEIT.value:
+            elif unit.upper() == self.TemperatureMetrics.FAHRENHEIT:
                 unit = self.TemperatureMetrics.FAHRENHEIT
             else:
                 unit = self.TemperatureMetrics.KELVIN
         else:
             unit = self.TemperatureMetrics.KELVIN
-        return unit.value
+        return unit.lower()
 
 
 class Distance(Model):
     value = FloatType(required=True)
 
-    class DistanceMetrics(Enum):
-        METERS = 'meters'
-        KILOMETERS = 'kilometers'
-        MILES = 'miles'
+    class DistanceMetrics(StringType, metaclass=EnumMeta):
+        METERS = 'METERS'
+        KILOMETERS = 'KILOMETERS'
+        MILES = 'MILES'
 
     @serializable(type=FloatType, serialized_name='value')
     def get_distance(self, *args, **kwargs):
         if hasattr(self, 'context'):
             distance = self.context.get('distance', 'meters')
 
-            if distance.lower() == self.DistanceMetrics.KILOMETERS.value:
+            if distance.upper() == self.DistanceMetrics.KILOMETERS:
                 value = round(self.value / 1000, 2) # Converts Meters distance to Kilometers
-            elif distance.lower() == self.DistanceMetrics.MILES.value:
+            elif distance.upper() == self.DistanceMetrics.MILES:
                 value = round(self.value / 1609.344, 2) # Converts Meters distance to Miles
             else:
                 value = round(self.value, 2) # Returns Meters distance
@@ -75,15 +75,15 @@ class Distance(Model):
         if hasattr(self, 'context'):
             unit = self.context.get('distance', 'meters')
 
-            if unit.lower() == self.DistanceMetrics.KILOMETERS.value:
+            if unit.lower() == self.DistanceMetrics.KILOMETERS:
                 unit = self.DistanceMetrics.KILOMETERS
-            elif unit.lower() == self.DistanceMetrics.MILES.value:
+            elif unit.lower() == self.DistanceMetrics.MILES:
                 unit = self.DistanceMetrics.MILES
             else:
                 unit = self.DistanceMetrics.METERS
         else:
             unit = self.DistanceMetrics.METERS
-        return unit.value
+        return unit.lower()
 
 
 class City(Model):

--- a/api/models/weather.py
+++ b/api/models/weather.py
@@ -12,18 +12,18 @@ class Temperature(Model):
     value = FloatType(required=True)
 
     class TemperatureMetrics(Enum):
-        CELSIUS = 1
-        FAHRENHEIT = 2
-        KELVIN = 3
+        CELSIUS = 'celsius'
+        FAHRENHEIT = 'fahrenheit'
+        KELVIN = 'kelvin'
 
     @serializable(type=FloatType, serialized_name='value')
     def get_temperature(self, *args, **kwargs):
         if hasattr(self, 'context'):
             temperature = self.context.get('temperature', 'kelvin')
 
-            if temperature.upper() == self.TemperatureMetrics.CELSIUS.name:
+            if temperature.lower() == self.TemperatureMetrics.CELSIUS.value:
                 value = round(self.value - 273.0, 2) # Converts Kelvin temperature to Celsius
-            elif temperature.upper() == self.TemperatureMetrics.FAHRENHEIT.name:
+            elif temperature.lower() == self.TemperatureMetrics.FAHRENHEIT.value:
                 value = round(1.8*(self.value-273.0)+32.0, 2) # Converts Kelvin temperature to Fahrenheit
             else:
                 value = round(self.value, 2) # Returns Kelvin temperature
@@ -36,33 +36,33 @@ class Temperature(Model):
         if hasattr(self, 'context'):
             unit = self.context.get('temperature', 'kelvin')
 
-            if unit.upper() == self.TemperatureMetrics.CELSIUS.name:
+            if unit.lower() == self.TemperatureMetrics.CELSIUS.value:
                 unit = self.TemperatureMetrics.CELSIUS
-            elif unit.upper() == self.TemperatureMetrics.FAHRENHEIT.name:
+            elif unit.lower() == self.TemperatureMetrics.FAHRENHEIT.value:
                 unit = self.TemperatureMetrics.FAHRENHEIT
             else:
                 unit = self.TemperatureMetrics.KELVIN
         else:
             unit = self.TemperatureMetrics.KELVIN
-        return unit.name.lower()
+        return unit.value
 
 
 class Distance(Model):
     value = FloatType(required=True)
 
     class DistanceMetrics(Enum):
-        METERS = 1
-        KILOMETERS = 2
-        MILES = 3
+        METERS = 'meters'
+        KILOMETERS = 'kilometers'
+        MILES = 'miles'
 
     @serializable(type=FloatType, serialized_name='value')
     def get_distance(self, *args, **kwargs):
         if hasattr(self, 'context'):
             distance = self.context.get('distance', 'meters')
 
-            if distance.upper() == self.DistanceMetrics.KILOMETERS.name:
+            if distance.lower() == self.DistanceMetrics.KILOMETERS.value:
                 value = round(self.value / 1000, 2) # Converts Meters distance to Kilometers
-            elif distance.upper() == self.DistanceMetrics.MILES.name:
+            elif distance.lower() == self.DistanceMetrics.MILES.value:
                 value = round(self.value / 1609.344, 2) # Converts Meters distance to Miles
             else:
                 value = round(self.value, 2) # Returns Meters distance
@@ -73,17 +73,17 @@ class Distance(Model):
     @serializable(type=StringType, serialized_name='unit')
     def get_unit(self, *args, **kwargs):
         if hasattr(self, 'context'):
-            unit = self.context.get('distance', 'kelvin')
+            unit = self.context.get('distance', 'meters')
 
-            if unit.upper() == self.DistanceMetrics.KILOMETERS.name:
+            if unit.lower() == self.DistanceMetrics.KILOMETERS.value:
                 unit = self.DistanceMetrics.KILOMETERS
-            elif unit.upper() == self.DistanceMetrics.MILES.name:
+            elif unit.lower() == self.DistanceMetrics.MILES.value:
                 unit = self.DistanceMetrics.MILES
             else:
                 unit = self.DistanceMetrics.METERS
         else:
             unit = self.DistanceMetrics.METERS
-        return unit.name.lower()
+        return unit.value
 
 
 class City(Model):

--- a/api/resources/weather.py
+++ b/api/resources/weather.py
@@ -38,10 +38,13 @@ class WeatherView(Resource):
 
         weather_cached = None
 
-        for weather in weather_list:
-            # Gets the weather in cache if exists
-            if unidecode(city_name.upper()) == weather['id']:
-                weather_cached = weather
+        if weather_list is not None:
+            for weather in weather_list:
+                # Gets the weather in cache if exists
+                if unidecode(city_name.upper()) == weather['id']:
+                    weather_cached = weather
+        else:
+            weather_list = []
 
         if weather_cached is not None:
             # Instances an existing weather in cache

--- a/api/resources/weather.py
+++ b/api/resources/weather.py
@@ -1,5 +1,6 @@
 from flask import request
 from flask_restful import Resource, reqparse
+from unidecode import unidecode
 from api import cache
 from api import openweathermap as owm
 from api.models.weather import Weather
@@ -30,20 +31,47 @@ class WeatherListView(Resource):
         return recent_weather_list, 200
 
 class WeatherView(Resource):
-    @cache.cached()
     def get(self, city_name):
 
-        # Request the weather in the specify city
-        response = owm.current_weather(city_name)
+        # Recovers the cached weather list
+        weather_list = cache.get('weather_list')
 
+        weather_cached = None
 
-        # Recover and update the weather list in the cache
+        for weather in weather_list:
+            # Gets the weather in cache if exists
+            if unidecode(city_name.upper()) == weather['id']:
+                weather_cached = weather
+
+        if weather_cached is not None:
+            # Instances an existing weather in cache
+            response = Weather(weather_cached)
+        else:
+            # Requests a new weather with the OpenWeatherMap API
+            response = owm.current_weather(city_name)
+            weather_list.append(response.to_primitive())
+            cache.set('weather_list', weather_list)
+
+        # Creates the context of the units of measurement
         if isinstance(response, Weather):
             weather = response
-            weather_list = cache.get('weather_list') if cache.get('weather_list') is not None else []
-            weather_list.append(weather.to_primitive())
-            cache.set('weather_list', weather_list)
+
+            # Creates the temperature context
+            temperature = request.args.get('temperature', 'kelvin')
+            temperature_context = {'temperature': temperature}
+            weather.temperature.context = temperature_context
+            if weather.feels_like is not None:
+                weather.feels_like.context = temperature_context
+            if weather.max_temperature is not None:
+                weather.max_temperature.context = temperature_context
+            if weather.min_temperature is not None:
+                weather.min_temperature.context = temperature_context
+
+            # Creates the distance context
+            distance = request.args.get('distance', 'meters')
+            distance_context = {'distance': distance}
+            weather.visibility.context = distance_context
         else:
             return response
 
-        return weather.serialize(), 200
+        return weather.to_primitive(), 200

--- a/api/resources/weather.py
+++ b/api/resources/weather.py
@@ -52,8 +52,10 @@ class WeatherView(Resource):
         else:
             # Requests a new weather with the OpenWeatherMap API
             response = owm.current_weather(city_name)
-            weather_list.append(response.to_primitive())
-            cache.set('weather_list', weather_list)
+
+            if isinstance(response, Weather):
+                weather_list.append(response.to_primitive())
+                cache.set('weather_list', weather_list)
 
         # Creates the context of the units of measurement
         if isinstance(response, Weather):

--- a/api/utils/metatypes.py
+++ b/api/utils/metatypes.py
@@ -1,0 +1,8 @@
+from schematics.types.base import TypeMeta
+
+# Inheriting this class will make an enum exhaustive
+class EnumMeta(TypeMeta):
+    def __new__(mcs, name, bases, attrs):
+        attrs['choices'] = [v for k, v in attrs.items(
+        ) if not k.startswith('_') and k.isupper()]
+        return TypeMeta.__new__(mcs, name, bases, attrs)

--- a/api/utils/openweathermap.py
+++ b/api/utils/openweathermap.py
@@ -1,5 +1,5 @@
 import os, requests
-from api.models.weather import PhysicalQuantity, City, Wind, Weather
+from api.models.weather import PhysicalQuantity, Temperature, Distance, City, Wind, Weather
 
 class OpenWeatherMap:
 
@@ -23,21 +23,17 @@ class OpenWeatherMap:
             }),
             'description': response['weather'][0]['main'].title(),
             'long_description': response['weather'][0]['description'].title(),
-            'temperature': PhysicalQuantity({
-                'value': float(response['main']['temp']),
-                'unit': 'celsius degree'
+            'temperature': Temperature({
+                'value': float(response['main']['temp'])
             }),
-            'feels_like': PhysicalQuantity({
-                'value': float(response['main']['feels_like']),
-                'unit': 'celsius degree'
+            'feels_like': Temperature({
+                'value': float(response['main']['feels_like'])
             }) if response['main']['feels_like'] != response['main']['temp'] else None,
-            'max_temperature': PhysicalQuantity({
-                'value': float(response['main']['temp_max']),
-                'unit': 'celsius degree'
+            'max_temperature': Temperature({
+                'value': float(response['main']['temp_max'])
             }) if response['main']['temp_max'] != response['main']['temp'] else None,
-            'min_temperature': PhysicalQuantity({
-                'value': float(response['main']['temp_min']),
-                'unit': 'celsius degree'
+            'min_temperature': Temperature({
+                'value': float(response['main']['temp_min'])
             }) if response['main']['temp_min'] != response['main']['temp'] else None,
             'wind': Wind({
                 'speed': PhysicalQuantity({
@@ -49,9 +45,8 @@ class OpenWeatherMap:
                     'unit': 'degrees'
                 })
             }),
-            'visibility': PhysicalQuantity({
-                'value': float(response['visibility']),
-                'unit': 'meters'
+            'visibility': Distance({
+                'value': float(response['visibility'])
             })
         })
 


### PR DESCRIPTION
This PR add a new unit conversion feature.

## New models available

Now, two models of metrics are available:

- Temperature
- Distance

This models manage the default value requested with the OpenWeatherMap API and return for the user the value converted to the desired unit.

This management is done by the context attribute.

## Usage the feature

**GET** `http://localhost:5000/weather/{city_name}` *get a city weather*

- **Parameters**

  |key|description|type|required|
  |-|-|-|-|
  |`temperature`|Converts all temperatures to the desired unit. Are available for use: `kelvin`, `celsius` and `fahrenheit`. If not informed, the default value will be `kelvin`.|string|**no**|
  |`distance`|Converts all distances to the desired unit. Are available for use: 'meters', 'kilometers' and 'miles'. If not informed, the default value will be `meters`.|string|**no**|

- **Responses**

  This is the result for `http://localhost:5000/weather/london` with `temperature=fahrenheit` and `distance=miles`:

  ```json
  {
    "city": {
      "name": "London",
      "country": "GB",
      "coordinates": [51.5085, -0.1257]
    },
    "description": "Clouds",
    "long_description": "Broken Clouds",
    "temperature": {
      "value": 53.92,
      "unit": "fahrenheit"
    },
    "feels_like": {
      "value": 51.33,
      "unit": "fahrenheit"
    },
    "max_temperature": {
      "value": 56.26,
      "unit": "fahrenheit"
    },
    "min_temperature": {
      "value": 53.28,
      "unit": "fahrenheit"
    },
    "wind": {
      "speed": {
        "value": 10.8,
        "unit": "meters per second"
      },
      "degree": {
        "value": 270.0,
        "unit": "degrees"
      }
    },
    "visibility": {
      "value": 6.21,
      "unit": "miles"
    },
    "id": "LONDON"
  }
  ```
